### PR TITLE
re-order operations around index.yaml

### DIFF
--- a/cmd/helms3/push.go
+++ b/cmd/helms3/push.go
@@ -69,30 +69,33 @@ func runPush(chartPath string, repoName string) error {
 
 	if _, err := storage.Upload(ctx, repoEntry.URL+"/"+fname, fchart); err != nil {
 		return errors.WithMessage(err, "upload chart to s3")
-	}
+	} else {
 	
-	// Fetch current index.
+		// Fetch current index.
 
-	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
-	defer cancel()
+		ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
+		defer cancel()
 
-	b, err := storage.FetchRaw(ctx, repoEntry.URL+"/index.yaml")
-	if err != nil {
-		return errors.WithMessage(err, "fetch current repo index")
-	}
+		b, err := storage.FetchRaw(ctx, repoEntry.URL+"/index.yaml")
+		if err != nil {
+			return errors.WithMessage(err, "fetch current repo index")
+		} else {
 
-	idx, err := index.LoadBytes(b)
-	if err != nil {
-		return errors.WithMessage(err, "load index from downloaded file")
-	}
+			idx, err := index.LoadBytes(b)
+			if err != nil {
+				return errors.WithMessage(err, "load index from downloaded file")
+			} else {
 
-	// Update index, then upload it to S3
+				// Update index, then upload it to S3
 
-	idx.Add(chart.GetMetadata(), fname, repoEntry.URL, hash)
-	idx.SortEntries()
+				idx.Add(chart.GetMetadata(), fname, repoEntry.URL, hash)
+				idx.SortEntries()
 
-	if _, err := storage.Upload(ctx, repoEntry.URL+"/index.yaml", idxReader); err != nil {
-		return errors.WithMessage(err, "upload index to s3")
+				if _, err := storage.Upload(ctx, repoEntry.URL+"/index.yaml", idxReader); err != nil {
+					return errors.WithMessage(err, "upload index to s3")
+				}
+			}
+		}
 	}
 
 	return nil


### PR DESCRIPTION
Moved the `index.yaml` retrieval _after_ updating the chart.tgz to reduce the window for race conditions. #18 