### PR TITLE
ability to define custom S3 ACL

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![License MIT](https://img.shields.io/badge/license-MIT-blue.svg?style=flat)](LICENSE)
 [![GitHub release](https://img.shields.io/github/release/hypnoglow/helm-s3.svg)](https://github.com/hypnoglow/helm-s3/releases)
 
-The Helm plugin that provides s3 protocol support. 
+The Helm plugin that provides s3 protocol support.
 
 This allows you to have private Helm chart repositories hosted on Amazon S3.
 
@@ -14,7 +14,7 @@ The installation itself is simple as:
 
     $ helm plugin install https://github.com/hypnoglow/helm-s3.git
 
-You can install a specific release version: 
+You can install a specific release version:
 
     $ helm plugin install https://github.com/hypnoglow/helm-s3.git --version 0.6.1
 
@@ -28,11 +28,11 @@ to the plugin, please see [these instructions](.github/CONTRIBUTING.md).
 Because this plugin assumes private access to S3, you need to provide valid AWS credentials.
 You can do this in [the same manner](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html) as for `AWS CLI` tool.
 
-So, if you want to use the plugin and you are already using `AWS CLI` - you are 
-good to go, no additional configuration required. Otherwise, follow [the official guide](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html) 
+So, if you want to use the plugin and you are already using `AWS CLI` - you are
+good to go, no additional configuration required. Otherwise, follow [the official guide](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html)
 to set up credentials.
 
-To minimize security issues, remember to configure your IAM user policies properly. 
+To minimize security issues, remember to configure your IAM user policies properly.
 As an example, a setup can provide only read access for users, and write access
 for a CI that builds and pushes charts to your repository.
 
@@ -45,14 +45,14 @@ and a chart archive `epicservice-0.5.1.tgz` under path `s3://bucket-name/charts/
 Add your repository:
 
     $ helm repo add coolcharts s3://bucket-name/charts
-    
+
 Now you can use it as any other Helm chart repository.
 Try:
 
     $ helm search coolcharts
     NAME                       	VERSION	  DESCRIPTION
     coolcharts/epicservice	    0.5.1     A Helm chart.
-    
+
     $ helm install coolchart/epicservice --version "0.5.1"
 
 Fetching also works:
@@ -65,7 +65,7 @@ To create a new repository, use **init**:
 
     $ helm s3 init s3://bucket-name/charts
 
-This command generates an empty **index.yaml** and uploads it to the S3 bucket 
+This command generates an empty **index.yaml** and uploads it to the S3 bucket
 under `/charts` key.
 
 To work with this repo by it's name, first you need to add it using native helm command:
@@ -83,19 +83,20 @@ you don't need to run `helm repo update`).
 
 Your pushed chart is available:
 
-    $ helm search mynewrepo 
+    $ helm search mynewrepo
     NAME                    VERSION	 DESCRIPTION
     mynewrepo/epicservice   0.7.2    A Helm chart.
 
 Note that the plugin denies push when the chart with the same version already exists
 in the repository. This behavior is intentional. It is useful, for example, in
 CI automated pushing: if someone forgets to bump chart version - the chart would
-not be overwritten. 
+not be overwritten.
 
 However, in some cases you want to replace existing chart version. To do so,
 add `--force` flag to a push command:
 
     $ helm s3 push --force ./epicservice-0.7.2.tgz mynewrepo
+
 
 ### Delete
 
@@ -107,9 +108,9 @@ As always, both remote and local repo indexes updated automatically.
 
 The chart is deleted from the repo:
 
-    $ helm search mynewrepo/epicservice 
+    $ helm search mynewrepo/epicservice
     No results found
-    
+
 ### Reindex
 
 If your repository somehow became inconsistent or broken, you can use reindex to recreate
@@ -122,6 +123,17 @@ the index in accordance with the charts in the repository.
 ## Uninstall
 
     $ helm plugin remove s3
+
+## ACLs
+
+In use cases where you share a repo across multiple AWS accounts,
+you may want the ability to define object ACLS to allow charts to persist there
+permissions across accounts.
+To do so, add the flag `--acl="ACL_POLICY"`. The list of ACLs can be [found here](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl):
+
+    $ helm s3 push --acl="bucket-owner-full-control" ./epicservice-0.7.2.tgz mynewrepo
+
+You can also set the default ACL be setting the `S3_ACL` environment variable.
 
 ## Using alternative S3-compatible vendors
 
@@ -146,7 +158,7 @@ for organizing your repositories.
 
 Contributions are welcome. Please see [these instructions](.github/CONTRIBUTING.md)
 that will help you to develop the plugin.
-    
+
 ## License
 
 [MIT](LICENSE)

--- a/cmd/helms3/delete.go
+++ b/cmd/helms3/delete.go
@@ -13,7 +13,7 @@ import (
 )
 
 type deleteAction struct {
-	name, version, repoName string
+	name, version, repoName, acl string
 }
 
 func (act deleteAction) Run(ctx context.Context) error {
@@ -61,7 +61,7 @@ func (act deleteAction) Run(ctx context.Context) error {
 	if err := storage.Delete(ctx, uri); err != nil {
 		return errors.WithMessage(err, "delete chart file from s3")
 	}
-	if err := storage.PutIndex(ctx, repoEntry.URL, idxReader); err != nil {
+	if err := storage.PutIndex(ctx, repoEntry.URL, act.acl, idxReader); err != nil {
 		return errors.WithMessage(err, "upload new index to s3")
 	}
 

--- a/cmd/helms3/init.go
+++ b/cmd/helms3/init.go
@@ -12,6 +12,7 @@ import (
 
 type initAction struct {
 	uri string
+	acl string
 }
 
 func (act initAction) Run(ctx context.Context) error {
@@ -26,7 +27,7 @@ func (act initAction) Run(ctx context.Context) error {
 	}
 	storage := awss3.New(sess)
 
-	if err := storage.PutIndex(ctx, act.uri, r); err != nil {
+	if err := storage.PutIndex(ctx, act.uri, act.acl, r); err != nil {
 		return errors.WithMessage(err, "upload index to s3")
 	}
 

--- a/cmd/helms3/push.go
+++ b/cmd/helms3/push.go
@@ -28,6 +28,7 @@ type pushAction struct {
 	chartPath string
 	repoName  string
 	force     bool
+	acl       string
 }
 
 func (act pushAction) Run(ctx context.Context) error {
@@ -93,7 +94,7 @@ func (act pushAction) Run(ctx context.Context) error {
 		return ErrChartExists
 	}
 
-	if _, err := storage.PutChart(ctx, repoEntry.URL+"/"+fname, fchart, string(serializedChartMeta), hash); err != nil {
+	if _, err := storage.PutChart(ctx, repoEntry.URL+"/"+fname, fchart, string(serializedChartMeta), act.acl, hash); err != nil {
 		return errors.WithMessage(err, "upload chart to s3")
 	}
 
@@ -123,7 +124,7 @@ func (act pushAction) Run(ctx context.Context) error {
 		return errors.WithMessage(err, "get index reader")
 	}
 
-	if err := storage.PutIndex(ctx, repoEntry.URL, idxReader); err != nil {
+	if err := storage.PutIndex(ctx, repoEntry.URL, act.acl, idxReader); err != nil {
 		return errors.WithMessage(err, "upload index to s3")
 	}
 

--- a/cmd/helms3/reindex.go
+++ b/cmd/helms3/reindex.go
@@ -13,6 +13,7 @@ import (
 
 type reindexAction struct {
 	repoName string
+	acl      string
 }
 
 func (act reindexAction) Run(ctx context.Context) error {
@@ -51,7 +52,7 @@ func (act reindexAction) Run(ctx context.Context) error {
 		return errors.Wrap(err, "get index reader")
 	}
 
-	if err := storage.PutIndex(ctx, repoEntry.URL, r); err != nil {
+	if err := storage.PutIndex(ctx, repoEntry.URL, act.acl, r); err != nil {
 		return errors.Wrap(err, "upload index to the repository")
 	}
 

--- a/internal/awss3/storage.go
+++ b/internal/awss3/storage.go
@@ -222,7 +222,7 @@ func (s *Storage) Exists(ctx context.Context, uri string) (bool, error) {
 
 // PutChart puts the chart file to the storage.
 // uri must be in the form of s3 protocol: s3://bucket-name/key[...].
-func (s *Storage) PutChart(ctx context.Context, uri string, r io.Reader, chartMeta, chartDigest string) (string, error) {
+func (s *Storage) PutChart(ctx context.Context, uri string, r io.Reader, chartMeta, acl string, chartDigest string) (string, error) {
 	bucket, key, err := parseURI(uri)
 	if err != nil {
 		return "", err
@@ -233,6 +233,7 @@ func (s *Storage) PutChart(ctx context.Context, uri string, r io.Reader, chartMe
 		&s3manager.UploadInput{
 			Bucket: aws.String(bucket),
 			Key:    aws.String(key),
+			ACL:    aws.String(acl),
 			Body:   r,
 			Metadata: map[string]*string{
 				metaChartMetadata: aws.String(chartMeta),
@@ -248,7 +249,7 @@ func (s *Storage) PutChart(ctx context.Context, uri string, r io.Reader, chartMe
 
 // PutIndex puts the index file to the storage.
 // uri must be in the form of s3 protocol: s3://bucket-name/key[...].
-func (s *Storage) PutIndex(ctx context.Context, uri string, r io.Reader) error {
+func (s *Storage) PutIndex(ctx context.Context, uri string, acl string, r io.Reader) error {
 	if strings.HasPrefix(uri, "index.yaml") {
 		return errors.New("uri must not contain \"index.yaml\" suffix, it appends automatically")
 	}
@@ -264,6 +265,7 @@ func (s *Storage) PutIndex(ctx context.Context, uri string, r io.Reader) error {
 		&s3manager.UploadInput{
 			Bucket: aws.String(bucket),
 			Key:    aws.String(key),
+			ACL:    aws.String(acl),
 			Body:   r,
 		})
 	if err != nil {


### PR DESCRIPTION
Addresses Issue #37

Allows setting of `--acl` flag to define custom ACL as per https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl for S3 operations.

Also adds the ability to fetch this ACL from ENV S3_ACL