### PR TITLE
specify a different base url for charts when pushing and reindexing

### DIFF
--- a/cmd/helms3/main.go
+++ b/cmd/helms3/main.go
@@ -73,10 +73,9 @@ func main() {
 		String()
 	pushForce := pushCmd.Flag("force", "Replace the chart if it already exists. This can cause the repository to lose existing chart; use it with care").
 		Bool()
-	repoBaseUrl := pushCmd.Flag("base-url", "the base url of the chart packages that are published").
-	  Default("").
+	repoBaseURL := pushCmd.Flag("base-url", "the base url of the chart packages that are published").
+		Default("").
 		String()
-
 
 	reindexCmd := cli.Command(actionReindex, "Reindex the repository.")
 	reindexTargetRepository := reindexCmd.Arg("repo", "Target repository to reindex").
@@ -117,14 +116,14 @@ func main() {
 			chartPath:   *pushChartPath,
 			repoName:    *pushTargetRepository,
 			force:       *pushForce,
-			repoBaseUrl: *repoBaseUrl,
+			repoBaseURL: *repoBaseURL,
 		}
 
 	case actionReindex:
 		fmt.Fprint(os.Stderr, "Warning: reindex feature is in beta. If you experience any issues,\nplease provide your feedback here: https://github.com/hypnoglow/helm-s3/issues/22\n\n")
 		act = reindexAction{
 			repoName:    *reindexTargetRepository,
-			repoBaseUrl: *repoBaseUrl,
+			repoBaseURL: *repoBaseURL,
 		}
 		defer fmt.Printf("Repository %s was successfully reindexed.\n", *reindexTargetRepository)
 

--- a/cmd/helms3/main.go
+++ b/cmd/helms3/main.go
@@ -73,6 +73,10 @@ func main() {
 		String()
 	pushForce := pushCmd.Flag("force", "Replace the chart if it already exists. This can cause the repository to lose existing chart; use it with care").
 		Bool()
+	repoBaseUrl := pushCmd.Flag("base-url", "the base url of the chart packages that are published").
+	  Default("").
+		String()
+
 
 	reindexCmd := cli.Command(actionReindex, "Reindex the repository.")
 	reindexTargetRepository := reindexCmd.Arg("repo", "Target repository to reindex").
@@ -110,15 +114,17 @@ func main() {
 
 	case actionPush:
 		act = pushAction{
-			chartPath: *pushChartPath,
-			repoName:  *pushTargetRepository,
-			force:     *pushForce,
+			chartPath:   *pushChartPath,
+			repoName:    *pushTargetRepository,
+			force:       *pushForce,
+			repoBaseUrl: *repoBaseUrl,
 		}
 
 	case actionReindex:
 		fmt.Fprint(os.Stderr, "Warning: reindex feature is in beta. If you experience any issues,\nplease provide your feedback here: https://github.com/hypnoglow/helm-s3/issues/22\n\n")
 		act = reindexAction{
-			repoName: *reindexTargetRepository,
+			repoName:    *reindexTargetRepository,
+			repoBaseUrl: *repoBaseUrl,
 		}
 		defer fmt.Printf("Repository %s was successfully reindexed.\n", *reindexTargetRepository)
 

--- a/cmd/helms3/push.go
+++ b/cmd/helms3/push.go
@@ -25,9 +25,10 @@ var (
 )
 
 type pushAction struct {
-	chartPath string
-	repoName  string
-	force     bool
+	chartPath   string
+	repoName    string
+	force       bool
+	repoBaseUrl string
 }
 
 func (act pushAction) Run(ctx context.Context) error {
@@ -113,7 +114,15 @@ func (act pushAction) Run(ctx context.Context) error {
 		return errors.WithMessage(err, "load index from downloaded file")
 	}
 
-	if err := idx.AddOrReplace(chart.GetMetadata(), fname, repoEntry.URL, hash); err != nil {
+  // if you have a public repository, you might want to set chart base url to the s3 buckets website address
+  var url string
+  if act.repoBaseUrl == "" {
+    url = repoEntry.URL
+  } else {
+  	url = act.repoBaseUrl
+  }
+
+	if err := idx.AddOrReplace(chart.GetMetadata(), fname, url, hash); err != nil {
 		return errors.WithMessage(err, "add/replace chart in the index")
 	}
 	idx.SortEntries()

--- a/cmd/helms3/push.go
+++ b/cmd/helms3/push.go
@@ -28,7 +28,7 @@ type pushAction struct {
 	chartPath   string
 	repoName    string
 	force       bool
-	repoBaseUrl string
+	repoBaseURL string
 }
 
 func (act pushAction) Run(ctx context.Context) error {
@@ -114,15 +114,15 @@ func (act pushAction) Run(ctx context.Context) error {
 		return errors.WithMessage(err, "load index from downloaded file")
 	}
 
-  // if you have a public repository, you might want to set chart base url to the s3 buckets website address
-  var url string
-  if act.repoBaseUrl == "" {
-    url = repoEntry.URL
-  } else {
-  	url = act.repoBaseUrl
-  }
+	// if you have a public repository, you might want to set chart base url to the s3 buckets website address
+	var repoBaseURL string
+	if act.repoBaseURL == "" {
+		repoBaseURL = repoEntry.URL
+	} else {
+		repoBaseURL = act.repoBaseURL
+	}
 
-	if err := idx.AddOrReplace(chart.GetMetadata(), fname, url, hash); err != nil {
+	if err := idx.AddOrReplace(chart.GetMetadata(), fname, repoBaseURL, hash); err != nil {
 		return errors.WithMessage(err, "add/replace chart in the index")
 	}
 	idx.SortEntries()

--- a/cmd/helms3/reindex.go
+++ b/cmd/helms3/reindex.go
@@ -13,6 +13,7 @@ import (
 
 type reindexAction struct {
 	repoName string
+	repoBaseUrl string
 }
 
 func (act reindexAction) Run(ctx context.Context) error {
@@ -29,11 +30,19 @@ func (act reindexAction) Run(ctx context.Context) error {
 
 	items, errs := storage.Traverse(ctx, repoEntry.URL)
 
+  // if you have a public repository, you might want to set chart base url to the s3 buckets website address
+  var url string
+  if act.repoBaseUrl == "" {
+    url = repoEntry.URL
+  } else {
+  	url = act.repoBaseUrl
+  }
+
 	builtIndex := make(chan *index.Index, 1)
 	go func() {
 		idx := index.New()
 		for item := range items {
-			idx.Add(item.Meta, item.Filename, repoEntry.URL, item.Hash)
+			idx.Add(item.Meta, item.Filename, url, item.Hash)
 		}
 		idx.SortEntries()
 

--- a/cmd/helms3/reindex.go
+++ b/cmd/helms3/reindex.go
@@ -12,8 +12,8 @@ import (
 )
 
 type reindexAction struct {
-	repoName string
-	repoBaseUrl string
+	repoName    string
+	repoBaseURL string
 }
 
 func (act reindexAction) Run(ctx context.Context) error {
@@ -30,19 +30,19 @@ func (act reindexAction) Run(ctx context.Context) error {
 
 	items, errs := storage.Traverse(ctx, repoEntry.URL)
 
-  // if you have a public repository, you might want to set chart base url to the s3 buckets website address
-  var url string
-  if act.repoBaseUrl == "" {
-    url = repoEntry.URL
-  } else {
-  	url = act.repoBaseUrl
-  }
+	// if you have a public repository, you might want to set chart base url to the s3 buckets website address
+	var repoBaseURL string
+	if act.repoBaseURL == "" {
+		repoBaseURL = repoEntry.URL
+	} else {
+		repoBaseURL = act.repoBaseURL
+	}
 
 	builtIndex := make(chan *index.Index, 1)
 	go func() {
 		idx := index.New()
 		for item := range items {
-			idx.Add(item.Meta, item.Filename, url, item.Hash)
+			idx.Add(item.Meta, item.Filename, repoBaseURL, item.Hash)
 		}
 		idx.SortEntries()
 


### PR DESCRIPTION
This enables you to publish charts with public s3 urls, which is useful when you are running a public repository. 
Ideally the url could be picked up from the s3 package and this would just be a flag?

This is really dependent on this
https://github.com/hypnoglow/helm-s3/pull/43