### PR TITLE
Updated post-install hook to execute `hack/install.sh` shell script directly.

### DIFF
--- a/plugin.yaml
+++ b/plugin.yaml
@@ -10,5 +10,5 @@ downloaders:
   protocols:
     - "s3"
 hooks:
-  install: "cd $HELM_PLUGIN_DIR; make install"
-  update: "cd $HELM_PLUGIN_DIR; make install"
+  install: "cd $HELM_PLUGIN_DIR; ./hack/install.sh"
+  update: "cd $HELM_PLUGIN_DIR; ./hack/install.sh"


### PR DESCRIPTION
This removes the dependency on `make` for end-users entirely, thus removing the need for updated documentation.

Refs: #62 