### PR TITLE
Add option to publish via a different URI

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ updating the index.
 The repository owner can continue to use the S3 URIs while the repository user can
 consume the repository via its published URI:
 
-   $ helm repo add publishedrepo https://charts.my-company.tld
+    $ helm repo add publishedrepo https://charts.my-company.tld
 
 ### Push
 

--- a/README.md
+++ b/README.md
@@ -117,6 +117,20 @@ To work with this repo by it's name, first you need to add it using native helm 
 
     $ helm repo add mynewrepo s3://bucket-name/charts
 
+To store the repository in S3, but to publish it at a different URI you can specify the
+URI when initializing. This will rewrite the URIs in the repository index so that they are
+downloadable via the published URI. This is useful in case you want to keep the S3
+bucket private and expose the repository over HTTP(S) via CloudFront or a web server.
+The delete and push commands will automatically take into account this publish URI when
+updating the index.
+
+    $ helm s3 init s3://bucket-name/charts --publish https://charts.my-company.tld
+
+The repository owner can continue to use the S3 URIs while the repository user can
+consume the repository via its published URI:
+
+   $ helm repo add publishedrepo https://charts.my-company.tld
+
 ### Push
 
 Now you can push your chart to this repo:
@@ -165,6 +179,10 @@ If your repository somehow became inconsistent or broken, you can use reindex to
 the index in accordance with the charts in the repository.
 
     $ helm s3 reindex mynewrepo
+
+Alternatively, you can specify `--publish uri` to reindex an existing repository with a
+different published URI. If you don't specify a publish URI, it will reset the repository
+back to using S3 URIs.
 
 ## Uninstall
 

--- a/cmd/helms3/init.go
+++ b/cmd/helms3/init.go
@@ -11,8 +11,9 @@ import (
 )
 
 type initAction struct {
-	uri string
-	acl string
+	uri        string
+	publishURI string
+	acl        string
 }
 
 func (act initAction) Run(ctx context.Context) error {
@@ -27,7 +28,7 @@ func (act initAction) Run(ctx context.Context) error {
 	}
 	storage := awss3.New(sess)
 
-	if err := storage.PutIndex(ctx, act.uri, act.acl, r); err != nil {
+	if err := storage.PutIndex(ctx, act.uri, act.publishURI, act.acl, r); err != nil {
 		return errors.WithMessage(err, "upload index to s3")
 	}
 

--- a/cmd/helms3/main.go
+++ b/cmd/helms3/main.go
@@ -7,7 +7,7 @@ import (
 	"os"
 	"time"
 
-	"gopkg.in/alecthomas/kingpin.v2"
+	kingpin "gopkg.in/alecthomas/kingpin.v2"
 )
 
 var (
@@ -76,6 +76,9 @@ func main() {
 	initURI := initCmd.Arg("uri", "URI of repository, e.g. s3://awesome-bucket/charts").
 		Required().
 		String()
+	initPublish := initCmd.Flag("publish", "The URI where the S3 bucket should be published").
+		Default("").
+		String()
 
 	pushCmd := cli.Command(actionPush, "Push chart to the repository.")
 	pushChartPath := pushCmd.Arg("chartPath", "Path to a chart, e.g. ./epicservice-0.5.1.tgz").
@@ -98,6 +101,9 @@ func main() {
 	reindexCmd := cli.Command(actionReindex, "Reindex the repository.")
 	reindexTargetRepository := reindexCmd.Arg("repo", "Target repository to reindex").
 		Required().
+		String()
+	reindexPublish := reindexCmd.Flag("publish", "The URI where the S3 bucket should be published").
+		Default("").
 		String()
 
 	deleteCmd := cli.Command(actionDelete, "Delete chart from the repository.").Alias("del")
@@ -125,8 +131,9 @@ func main() {
 
 	case actionInit:
 		act = initAction{
-			uri: *initURI,
-			acl: *acl,
+			uri:        *initURI,
+			publishURI: *initPublish,
+			acl:        *acl,
 		}
 		defer fmt.Printf("Initialized empty repository at %s\n", *initURI)
 
@@ -143,8 +150,9 @@ func main() {
 
 	case actionReindex:
 		act = reindexAction{
-			repoName: *reindexTargetRepository,
-			acl:      *acl,
+			repoName:   *reindexTargetRepository,
+			publishURI: *reindexPublish,
+			acl:        *acl,
 		}
 		defer fmt.Printf("Repository %s was successfully reindexed.\n", *reindexTargetRepository)
 

--- a/hack/integration-tests-local.sh
+++ b/hack/integration-tests-local.sh
@@ -30,9 +30,6 @@ go build -o bin/helms3 ./cmd/helms3
 ## Test
 
 bash "$(dirname ${BASH_SOURCE[0]})/integration-tests.sh"
-if [ $? -eq 0 ] ; then
-    echo -e "\nAll tests passed!"
-fi
 
 ## Tear down
 

--- a/hack/integration-tests.sh
+++ b/hack/integration-tests.sh
@@ -2,145 +2,96 @@
 set -euo pipefail
 set -x
 
-#
 # Set up
-#
+BUCKET="test-bucket/charts"
+CONTENT_TYPE="application/x-gzip"
+MINIO="helm-s3-minio/${BUCKET}"
+PUBLISH_URI="http://example.com/charts"
+REPO="test-repo"
+S3_URI="s3://${BUCKET}"
+TEST_CASE=""
+
+function cleanup() {
+    rc=$?
+    set +x
+    rm -f postgresql-0.8.3.tgz
+    helm repo remove "${REPO}" &>/dev/null
+
+    if [[ ${rc} -eq 0 ]]; then
+        echo -e "\nAll tests passed!"
+    else
+        echo -e "\nTest failed: ${TEST_CASE}"
+    fi
+}
+
+trap cleanup EXIT
 
 # Prepare chart to play with.
 helm fetch stable/postgresql --version 0.8.3
+helm repo remove "${REPO}" &>/dev/null || true
 
-#
-# Test: init repo
-#
+TEST_CASE="helm s3 init"
+helm s3 init "${S3_URI}"
+mc ls "${MINIO}/index.yaml" &>/dev/null
+helm repo add "${REPO}" "${S3_URI}"
 
-helm s3 init s3://test-bucket/charts
-if [ $? -ne 0 ]; then
-    echo "Failed to initialize repo"
-    exit 1
-fi
+TEST_CASE="helm s3 push"
+helm s3 push postgresql-0.8.3.tgz "${REPO}"
+mc ls "${MINIO}/postgresql-0.8.3.tgz" &>/dev/null
+helm search "${REPO}/postgres" | grep -q 0.8.3
 
-mc ls helm-s3-minio/test-bucket/charts/index.yaml
-if [ $? -ne 0 ]; then
-    echo "Repository was not actually initialized"
-    exit 1
-fi
+TEST_CASE="helm s3 push fails"
+! helm s3 push postgresql-0.8.3.tgz "${REPO}" 2>/dev/null
 
-helm repo add test-repo s3://test-bucket/charts
-if [ $? -ne 0 ]; then
-    echo "Failed to add repo"
-    exit 1
-fi
+TEST_CASE="helm s3 push --force"
+helm s3 push --force postgresql-0.8.3.tgz "${REPO}"
 
-#
-# Test: push chart
-#
+TEST_CASE="helm fetch"
+helm fetch "${REPO}/postgresql" --version 0.8.3
 
-helm s3 push postgresql-0.8.3.tgz test-repo
-if [ $? -ne 0 ]; then
-    echo "Failed to push chart to repo"
-    exit 1
-fi
+TEST_CASE="helm s3 reindex --publish <uri>"
+helm s3 reindex "${REPO}" --publish "${PUBLISH_URI}"
+mc cat "${MINIO}/index.yaml" | grep -Fqw "${PUBLISH_URI}/postgresql-0.8.3.tgz"
+mc stat "${MINIO}/index.yaml" | grep "X-Amz-Meta-Helm-S3-Publish-Uri" | grep -Fqw "${PUBLISH_URI}"
 
-mc ls helm-s3-minio/test-bucket/charts/postgresql-0.8.3.tgz
-if [ $? -ne 0 ]; then
-    echo "Chart was not actually uploaded"
-    exit 1
-fi
+TEST_CASE="helm s3 reindex"
+helm s3 reindex "${REPO}"
+mc cat "${MINIO}/index.yaml" | grep -Fqw "${S3_URI}/postgresql-0.8.3.tgz"
+mc stat "${MINIO}/index.yaml" | grep -w "X-Amz-Meta-Helm-S3-Publish-Uri\s*:\s*$"
 
-helm search test-repo/postgres | grep -q 0.8.3
-if [ $? -ne 0 ]; then
-    echo "Failed to find uploaded chart"
-    exit 1
-fi
+TEST_CASE="helm s3 delete"
+helm s3 delete postgresql --version 0.8.3 "${REPO}"
+! mc ls -q "${MINIO}/postgresql-0.8.3.tgz" 2>/dev/null
+! helm search "${REPO}/postgres" | grep -Fq 0.8.3
 
-#
-# Test: push the same chart again
-#
+TEST_CASE="helm s3 push --content-type <type>"
+helm s3 push --content-type=${CONTENT_TYPE} postgresql-0.8.3.tgz "${REPO}"
+helm search "${REPO}/postgres" | grep -Fq 0.8.3
+mc ls "${MINIO}/postgresql-0.8.3.tgz" &>/dev/null
+mc stat "${MINIO}/postgresql-0.8.3.tgz" | grep "Content-Type" | grep -Fqw "${CONTENT_TYPE}"
 
-set +e # next command should return non-zero status
+# Cleanup to test published repo
+helm repo remove "${REPO}"
+mc rm --recursive --force "${MINIO}"
 
-helm s3 push postgresql-0.8.3.tgz test-repo
-if [ $? -eq 0 ]; then
-    echo "The same chart must not be pushed again"
-    exit 1
-fi
+TEST_CASE="helm s3 init --publish <uri>"
+helm s3 init "${S3_URI}" --publish "${PUBLISH_URI}"
+mc ls "${MINIO}/index.yaml" &>/dev/null
+mc stat "${MINIO}/index.yaml" | grep "X-Amz-Meta-Helm-S3-Publish-Uri" | grep -Fqw "${PUBLISH_URI}"
+helm repo add "${REPO}" "${S3_URI}"
 
-set -e
+TEST_CASE="helm s3 push (publish)"
+helm s3 push postgresql-0.8.3.tgz "${REPO}"
+mc ls "${MINIO}/postgresql-0.8.3.tgz" &>/dev/null
+mc cat "${MINIO}/index.yaml" | grep -Fqw "${PUBLISH_URI}/postgresql-0.8.3.tgz"
+mc stat "${MINIO}/index.yaml" | grep "X-Amz-Meta-Helm-S3-Publish-Uri" | grep -Fqw "${PUBLISH_URI}"
+helm search "${REPO}/postgres" | grep -Fq 0.8.3
 
-helm s3 push --force postgresql-0.8.3.tgz test-repo
-if [ $? -ne 0 ]; then
-    echo "The same chart must be pushed again using --force"
-    exit 1
-fi
+TEST_CASE="helm fetch (publish)"
+helm fetch "${REPO}/postgresql" --version 0.8.3
 
-#
-# Test: fetch chart
-#
-
-helm fetch test-repo/postgresql --version 0.8.3
-if [ $? -ne 0 ]; then
-    echo "Failed to fetch chart from repo"
-    exit 1
-fi
-
-#
-# Test: delete chart
-#
-
-helm s3 delete postgresql --version 0.8.3 test-repo
-if [ $? -ne 0 ]; then
-    echo "Failed to delete chart from repo"
-    exit 1
-fi
-
-if mc ls -q helm-s3-minio/test-bucket/charts/postgresql-0.8.3.tgz 2>/dev/null ; then
-    echo "Chart was not actually deleted"
-    exit 1
-fi
-
-if helm search test-repo/postgres | grep -q 0.8.3 ; then
-    echo "Failed to delete chart from index"
-    exit 1
-fi
-
-#
-# Test: push with content-type
-#
-expected_content_type='application/gzip'
-helm s3 push --content-type=${expected_content_type} postgresql-0.8.3.tgz test-repo
-if [ $? -ne 0 ]; then
-    echo "Failed to push chart to repo"
-    exit 1
-fi
-
-helm search test-repo/postgres | grep -q 0.8.3
-if [ $? -ne 0 ]; then
-    echo "Failed to find uploaded chart"
-    exit 1
-fi
-
-mc ls helm-s3-minio/test-bucket/charts/postgresql-0.8.3.tgz
-if [ $? -ne 0 ]; then
-    echo "Chart was not actually uploaded"
-    exit 1
-fi
-
-actual_content_type=$(mc stat helm-s3-minio/test-bucket/charts/postgresql-0.8.3.tgz | awk '/Content-Type/{print $NF}')
-if [ $? -ne 0 ]; then
-    echo "failed to stat uploaded chart"
-    exit 1
-fi
-
-if [ "${expected_content_type}" != "${actual_content_type}" ]; then
-    echo "content-type, expected '${expected_content_type}', actual '${actual_content_type}'"
-    exit 1
-fi
-
-#
-# Tear down
-#
-
-rm postgresql-0.8.3.tgz
-helm repo remove test-repo
-set +x
-
+TEST_CASE="helm s3 delete (publish)"
+helm s3 delete postgresql --version 0.8.3 "${REPO}"
+mc stat "${MINIO}/index.yaml" | grep "X-Amz-Meta-Helm-S3-Publish-Uri" | grep -Fqw "${PUBLISH_URI}"
+! mc ls -q "${MINIO}/postgresql-0.8.3.tgz" 2>/dev/null
+! helm search "${REPO}/postgres" | grep -Fq 0.8.3


### PR DESCRIPTION
Fixes #45 

This PR implements the proposal in PR #56, but addresses the concerns that I had with the proposal. It does so by maintaining the remote and local indexes separately such that the remote one has the published URI (HTTP) while the local always has the S3 URIs. Besides solving the problem with authenticated repositories while still supporting the other use cases, I think it is more intuitive that the Helm S3 plugin continues to use S3 as its protocol regardless of how the repository user consumes the publish repository.

I also merged the publish command into a `helm s3 reindex --publish` since the publish command was effectively a reindex command with a different publish URI.