### PR TITLE
Environment variable for S3 bucket location

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,12 @@ See [these integration tests](https://github.com/hypnoglow/helm-s3/blob/master/h
 
 To enable S3 SSE export environment variable `AWS_S3_SSE` and set it to desired type for example `AES256`.
 
+## S3 bucket location
+
+The plugin will look for the bucket in the region inferred by the environment. If the bucket is in another region, the commands will fail.
+
+This can be controlled by exporting one of HELM\_S3\_REGION, AWS\_REGION or AWS\_DEFAULT\_REGION, in order of precedence.
+
 ## Documentation
 
 Additional documentation is available in the [docs](docs) directory. This currently includes:

--- a/internal/awsutil/session.go
+++ b/internal/awsutil/session.go
@@ -14,6 +14,10 @@ const (
 
 	// awsDisableSSL can be set to true to disable SSL for AWS S3 server.
 	awsDisableSSL = "AWS_DISABLE_SSL"
+
+	// awsBucketLocation can be set to an AWS region to force the session region
+	// if AWS_DEFAULT_REGION and AWS_REGION cannot be trusted
+	awsBucketLocation = "HELM_S3_REGION"
 )
 
 // SessionOption is an option for session.
@@ -41,6 +45,13 @@ func Session(opts ...SessionOption) (*session.Session, error) {
 		},
 		SharedConfigState:       session.SharedConfigEnable,
 		AssumeRoleTokenProvider: StderrTokenProvider,
+	}
+
+	bucketRegion := os.Getenv(awsBucketLocation)
+	// if not set, we don't update the config,
+	// so that the AWS SDK can still rely on either AWS_REGION or AWS_DEFAULT_REGION
+	if bucketRegion != "" {
+		so.Config.Region = aws.String(bucketRegion)
 	}
 
 	for _, opt := range opts {

--- a/internal/awsutil/session_test.go
+++ b/internal/awsutil/session_test.go
@@ -8,6 +8,7 @@ import (
 func TestSessionWithCustomEndpoint(t *testing.T) {
 	os.Setenv("AWS_ENDPOINT", "foobar:1234")
 	os.Setenv("AWS_DISABLE_SSL", "true")
+	os.Setenv("HELM_S3_REGION", "us-west-2")
 
 	s, err := Session()
 	if err != nil {
@@ -22,6 +23,10 @@ func TestSessionWithCustomEndpoint(t *testing.T) {
 		t.Fatalf("Expected to disable SSL")
 	}
 
+	if *s.Config.Region != "us-west-2" {
+		t.Fatalf("Expected to set us-west-2 region")
+	}
 	os.Unsetenv("AWS_ENDPOINT")
 	os.Unsetenv("AWS_DISABLE_SSL")
+	os.Unsetenv("HELM_S3_REGION")
 }


### PR DESCRIPTION
The region for the S3 bucket can already be influenced by AWS_REGION or AWS_DEFAULT_REGION. But in some cases these variables may have to be set to another value (for example I'm using helmsman with S3 bucket in us-west-2 for helm-s3, but also SSM parameters in us-east-1).

This MR adds a helm-s3 specific environment variable to force the bucket location.

References #51

Signed-off-by: Nicolas Degory <ndegory@axway.com>