### PR TITLE
Add support for AWS SSO

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/stretchr/testify v1.4.0
 	gopkg.in/alecthomas/kingpin.v2 v2.2.6
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
-	gopkg.in/ini.v1 v1.49.0 // indirect
+	gopkg.in/ini.v1 v1.49.0
 	helm.sh/helm/v3 v3.0.0
 	k8s.io/helm v2.16.1+incompatible
 	sigs.k8s.io/yaml v1.1.0

--- a/internal/awsutil/session.go
+++ b/internal/awsutil/session.go
@@ -4,6 +4,7 @@ import (
 	"os"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/session"
 )
 
@@ -14,6 +15,9 @@ const (
 
 	// awsDisableSSL can be set to true to disable SSL for AWS S3 server.
 	awsDisableSSL = "AWS_DISABLE_SSL"
+
+	// awsSSO can be set to true to enable the SSO credential provider
+	awsSSO = "AWS_SSO"
 )
 
 // SessionOption is an option for session.
@@ -41,6 +45,14 @@ func Session(opts ...SessionOption) (*session.Session, error) {
 		},
 		SharedConfigState:       session.SharedConfigEnable,
 		AssumeRoleTokenProvider: StderrTokenProvider,
+	}
+
+	if os.Getenv(awsSSO) == "true" {
+		ssoCredentialProvider, err := NewSSOCredentialProvider(os.Getenv("AWS_PROFILE"))
+		if err != nil {
+			return nil, err
+		}
+		so.Config.Credentials = credentials.NewCredentials(ssoCredentialProvider)
 	}
 
 	for _, opt := range opts {

--- a/internal/awsutil/sso_provider.go
+++ b/internal/awsutil/sso_provider.go
@@ -1,0 +1,185 @@
+package awsutil
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/sso"
+	"gopkg.in/ini.v1"
+)
+
+// Profile represents an AWS SSO profile section, as expected in the AWS config file
+type Profile struct {
+	Name         string
+	SSOAccountID string `ini:"sso_account_id"`
+	SSORegion    string `ini:"sso_region"`
+	SSOStartURL  string `ini:"sso_start_url"`
+	SSORoleName  string `ini:"sso_role_name"`
+}
+
+// SSOCache represents an AWS SSO cache file
+type SSOCache struct {
+	StartURL    string `json:"startUrl"`
+	Region      string `json:"region"`
+	AccessToken string `json:"accessToken"`
+	ExpiresAt   string `json:"expiresAt"`
+}
+
+// SSOCredentialProvider is a custom AWS credential provider to retrieve credentials which can be used with the SDK from SSO tokens
+type SSOCredentialProvider struct {
+	Session   *session.Session
+	AccountID string
+	RoleName  string
+	Cache     *SSOCache
+}
+
+var awsCachePath string
+var awsConfigPath string
+
+func init() {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		log.Fatal(err)
+	}
+	awsCachePath = filepath.Join(home, ".aws/sso/cache")
+	awsConfigPath = filepath.Join(home, ".aws/config")
+}
+
+// NewSSOCredentialProvider returns an initialised SSOCredentialProvider
+func NewSSOCredentialProvider(awsProfile string) (*SSOCredentialProvider, error) {
+	if awsProfile == "" {
+		awsProfile = os.Getenv("AWS_PROFILE")
+	}
+	profile, err := getProfile(awsProfile)
+	if err != nil {
+		return nil, err
+	}
+	provider := &SSOCredentialProvider{
+		Session: session.Must(session.NewSession(&aws.Config{
+			Region: &profile.SSORegion,
+		})),
+		AccountID: profile.SSOAccountID,
+		RoleName:  profile.SSORoleName,
+	}
+	provider.Cache, err = getCache(awsCachePath)
+	if err != nil {
+		return nil, err
+	}
+	return provider, nil
+}
+
+// Retrieve retrieves a set of temporary credentials using the access token from the cache
+func (p *SSOCredentialProvider) Retrieve() (credentials.Value, error) {
+	in := &sso.GetRoleCredentialsInput{
+		AccountId:   &p.AccountID,
+		RoleName:    &p.RoleName,
+		AccessToken: &p.Cache.AccessToken,
+	}
+	svc := sso.New(p.Session)
+	out, err := svc.GetRoleCredentials(in)
+	if err != nil {
+		return credentials.Value{}, err
+	}
+	return credentials.Value{
+		ProviderName:    "SSOCredentialProvider",
+		AccessKeyID:     *out.RoleCredentials.AccessKeyId,
+		SecretAccessKey: *out.RoleCredentials.SecretAccessKey,
+		SessionToken:    *out.RoleCredentials.SessionToken,
+	}, nil
+}
+
+// IsExpired determines if the cached SSO token is expired
+func (p *SSOCredentialProvider) IsExpired() bool {
+	t, err := time.Parse("2006-01-02T15:04:05UTC", p.Cache.ExpiresAt)
+	if err != nil {
+		log.Fatal(err)
+	}
+	return t.Before(time.Now())
+}
+
+func getCacheFile(path string) (*SSOCache, error) {
+	cache := &SSOCache{}
+	b, err := ioutil.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	err = json.Unmarshal(b, cache)
+	if err != nil {
+		return nil, err
+	}
+	return cache, nil
+}
+
+func getCache(cacheDir string) (*SSOCache, error) {
+
+	cache := &SSOCache{}
+
+	err := filepath.Walk(cacheDir, func(path string, info os.FileInfo, err error) error {
+		// handle failure accessing a path
+		if err != nil {
+			return err
+		}
+		// skip directories (excluding the cache dir itself)
+		if info.IsDir() && path != cacheDir {
+			return filepath.SkipDir
+		}
+		// skip anything that's not a json file
+		if !strings.HasSuffix(path, ".json") {
+			return nil
+		}
+		// skip the botocore files
+		if strings.HasPrefix(filepath.Base(path), "botocore-") {
+			return nil
+		}
+		// get the cache details from file
+		cache, err = getCacheFile(path)
+		if err != nil {
+			return err
+		}
+		return io.EOF
+	})
+
+	if err != nil && err != io.EOF {
+		return nil, err
+	}
+
+	return cache, nil
+
+}
+
+func getProfile(name string) (*Profile, error) {
+	if name == "" {
+		name = "default"
+	}
+	cfg, err := ini.Load(awsConfigPath)
+	if err != nil {
+		return nil, err
+	}
+	var section string
+	if name == "default" {
+		section = "default"
+	} else {
+		section = fmt.Sprintf("profile %s", name)
+	}
+	s, err := cfg.GetSection(section)
+	if err != nil {
+		return nil, err
+	}
+	return &Profile{
+		Name:         name,
+		SSOAccountID: s.Key("sso_account_id").String(),
+		SSORegion:    s.Key("sso_region").String(),
+		SSOStartURL:  s.Key("sso_start_url").String(),
+		SSORoleName:  s.Key("sso_role_name").String(),
+	}, nil
+}

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,5 +1,5 @@
 name: "s3"
-version: "0.9.2"
+version: "0.10.0"
 usage: "Manage chart repositories on Amazon S3"
 description: |-
   The plugin allows to use s3 protocol to upload, fetch charts and to work with repositories.


### PR DESCRIPTION
Annoyingly the AWS SDK for Go doesn't natively support credentials via SSO access tokens.
It does however provide the ability to create a custom credential provider - see [here](https://docs.aws.amazon.com/sdk-for-go/api/aws/credentials/)
This PR adds a custom credential provider capable of utilising the SSO token from the SSO token cache.
It's enabled via the env var `AWS_SSO` and relies on the `AWS_PROFILE` env var to get the SSO account ID and role name from the AWS config file in `~/.aws/config`.