### PR TITLE
fixing assumed profile issus for HELMS3_REGION

### DIFF
--- a/internal/awsutil/session.go
+++ b/internal/awsutil/session.go
@@ -51,6 +51,9 @@ func Session(opts ...SessionOption) (*session.Session, error) {
 	// if not set, we don't update the config,
 	// so that the AWS SDK can still rely on either AWS_REGION or AWS_DEFAULT_REGION
 	if bucketRegion != "" {
+		os.Unsetenv("AWS_SESSION_TOKEN")
+		os.Unsetenv("AWS_ACCESS_KEY_ID")
+		os.Unsetenv("AWS_SECRET_ACCESS_KEY")
 		so.Config.Region = aws.String(bucketRegion)
 	}
 


### PR DESCRIPTION
When using helm s3 plugin with assumed roles on instances, the switch for just the region does not work, as the existing session is bound to region of the role already. 
This has no impact on the .aws/profile use case as it would not even use the ENV vars which are central to the assume role setups most people have. 

This should fix https://github.com/hypnoglow/helm-s3/issues/128 as well