### PR TITLE
helm-s3 regional URL support

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,9 +290,11 @@ To enable S3 SSE export environment variable `AWS_S3_SSE` and set it to desired 
 
 ### S3 bucket location
 
-The plugin will look for the bucket in the region inferred by the environment. If the bucket is in another region, the commands will fail.
+You may specify a region for the bucket within the URL like so `s3://region@bucket-name/charts`.
 
-This can be controlled by exporting one of `HELM_S3_REGION`, `AWS_REGION` or `AWS_DEFAULT_REGION`, in order of precedence.
+Alternatively the plugin will look for the bucket in the region inferred by the environment. If the bucket is in another region, the commands will fail.
+
+This can be controlled by exporting one of `HELM_S3_REGION`, `AWS_REGION` or `AWS_DEFAULT_REGION`, in order of precedence (with URL being highest precedence).
 
 ## Additional Documentation
 

--- a/cmd/helms3/init.go
+++ b/cmd/helms3/init.go
@@ -21,7 +21,7 @@ func (act initAction) Run(ctx context.Context) error {
 		return errors.WithMessage(err, "get index reader")
 	}
 
-	sess, err := awsutil.Session()
+	sess, err := awsutil.Session(awsutil.WithRegionFromURI(act.uri))
 	if err != nil {
 		return err
 	}

--- a/cmd/helms3/proxy.go
+++ b/cmd/helms3/proxy.go
@@ -18,7 +18,7 @@ type proxyCmd struct {
 const indexYaml = "index.yaml"
 
 func (act proxyCmd) Run(ctx context.Context) error {
-	sess, err := awsutil.Session(awsutil.AssumeRoleTokenProvider(awsutil.StderrTokenProvider))
+	sess, err := awsutil.Session(awsutil.AssumeRoleTokenProvider(awsutil.StderrTokenProvider), awsutil.WithRegionFromURI(act.uri))
 	if err != nil {
 		return err
 	}

--- a/cmd/helms3/push.go
+++ b/cmd/helms3/push.go
@@ -44,10 +44,17 @@ func (act pushAction) Run(ctx context.Context) error {
 		return ErrForceAndIgnoreIfExists
 	}
 
-	sess, err := awsutil.Session()
+	repoEntry, err := helmutil.LookupRepoEntry(act.repoName)
 	if err != nil {
 		return err
 	}
+
+	// build our session
+	sess, err := awsutil.Session(awsutil.WithRegionFromURI(repoEntry.URL()))
+	if err != nil {
+		return err
+	}
+
 	storage := awss3.New(sess)
 
 	fpath, err := filepath.Abs(act.chartPath)
@@ -66,11 +73,6 @@ func (act pushAction) Run(ctx context.Context) error {
 	// and upload the chart right away.
 
 	chart, err := helmutil.LoadChart(fname)
-	if err != nil {
-		return err
-	}
-
-	repoEntry, err := helmutil.LookupRepoEntry(act.repoName)
 	if err != nil {
 		return err
 	}

--- a/cmd/helms3/reindex.go
+++ b/cmd/helms3/reindex.go
@@ -23,7 +23,7 @@ func (act reindexAction) Run(ctx context.Context) error {
 		return err
 	}
 
-	sess, err := awsutil.Session()
+	sess, err := awsutil.Session(awsutil.WithRegionFromURI(repoEntry.URL()))
 	if err != nil {
 		return err
 	}

--- a/internal/awsutil/session.go
+++ b/internal/awsutil/session.go
@@ -30,6 +30,20 @@ func AssumeRoleTokenProvider(provider func() (string, error)) SessionOption {
 	}
 }
 
+// WithRegionFromURI allows a session to be constructed with a region
+func WithRegionFromURI(uri string) SessionOption {
+	return func(options *session.Options) {
+		_, _, region, err := ParseURI(uri)
+		if err != nil {
+			return
+		}
+
+		if region != "" {
+			options.Config.Region = &region
+		}
+	}
+}
+
 // Session returns an AWS session as described http://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html
 func Session(opts ...SessionOption) (*session.Session, error) {
 	disableSSL := false

--- a/internal/awsutil/uri.go
+++ b/internal/awsutil/uri.go
@@ -1,0 +1,27 @@
+package awsutil
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/pkg/errors"
+)
+
+// ParseURI returns bucket, key and region from URIs like:
+// - s3://bucket-name/dir
+// - s3://bucket-name/dir/file.ext
+// - s3://region@bucket-name/dir/file.ext
+func ParseURI(uri string) (bucket, key, region string, err error) {
+	if !strings.HasPrefix(uri, "s3://") {
+		return "", "", "", fmt.Errorf("uri %s protocol is not s3", uri)
+	}
+
+	u, err := url.Parse(uri)
+	if err != nil {
+		return "", "", "", errors.Wrapf(err, "parse uri %s", uri)
+	}
+
+	bucket, key, region = u.Host, strings.TrimPrefix(u.Path, "/"), u.User.Username()
+	return bucket, key, region, nil
+}

--- a/internal/awsutil/uri_test.go
+++ b/internal/awsutil/uri_test.go
@@ -1,0 +1,40 @@
+package awsutil
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseNonRegionalURI(t *testing.T) {
+	// ParseURI returns bucket, key and region from URIs like:
+	// - s3://bucket-name/dir
+	// - s3://bucket-name/dir/file.ext
+	// - s3://region@bucket-name/dir/file.ext
+
+	uri := "s3://bucket-name/dir"
+	wantBucket, wantKey, wantRegion := "bucket-name", "dir", ""
+
+	bucket, key, region, err := ParseURI(uri)
+	assert.NoError(t, err)
+
+	assert.Equal(t, wantBucket, bucket)
+	assert.Equal(t, wantKey, key)
+	assert.Equal(t, wantRegion, region)
+}
+
+func TestParseRegionalURI(t *testing.T) {
+	// ParseURI returns bucket, key and region from URIs like:
+	// - s3://bucket-name/dir
+	// - s3://bucket-name/dir/file.ext
+	// - s3://region@bucket-name/dir/file.ext
+	uri := "s3://us-west-2@bucket-name/dir"
+	wantBucket, wantKey, wantRegion := "bucket-name", "dir", "us-west-2"
+
+	bucket, key, region, err := ParseURI(uri)
+	assert.NoError(t, err)
+
+	assert.Equal(t, wantBucket, bucket)
+	assert.Equal(t, wantKey, key)
+	assert.Equal(t, wantRegion, region)
+}


### PR DESCRIPTION
This PR introduces the ability for S3 URLs to contain the region within what would normally be the Username parameter:

```
helm repo add my-charts s3://us-west-2@my-charts-repository
```

The URL is backwards compatible, so users who are currently using normal URL's will not be impacted by the feature.
This allows us to install helm charts in repositories that are in disparate regions without needing to export additional variables.