### PR TITLE
Disabled cgo in dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,12 +8,9 @@ WORKDIR /workspace/helm-s3
 
 COPY . .
 
-RUN apk add --no-cache \
-    git \
-    gcc \
-    musl-dev
+RUN apk add --no-cache git
 
-RUN go build -o bin/helms3 \
+RUN CGO_ENABLED=0 go build -o bin/helms3 \
     -mod=vendor \
     -ldflags "-X main.version=${PLUGIN_VERSION}" \
     ./cmd/helms3

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,10 @@ WORKDIR /workspace/helm-s3
 
 COPY . .
 
-RUN apk add --no-cache git
+RUN apk add --no-cache \
+    git \
+    gcc \
+    musl-dev
 
 RUN go build -o bin/helms3 \
     -mod=vendor \


### PR DESCRIPTION
Added gcc and musl-dev apk's to fix cgo build dependencies.

This should hopefully unblock the master pipeline.