### PR TITLE
Support shell for install script

### DIFF
--- a/hack/install.sh
+++ b/hack/install.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 
 set \
   -o errexit \


### PR DESCRIPTION
I was trying to install the plugin in the helm container where bash is not available and the installation failed. Can we just make it `sh`? I was able to install successfully with this.