### PR TITLE
Output instead of CombinedOutput when parsing helm version output

### DIFF
--- a/internal/helmutil/version.go
+++ b/internal/helmutil/version.go
@@ -30,7 +30,7 @@ var helm3Detected func() bool
 
 func helmVersionCommand() bool {
 	cmd := exec.Command("helm", "version", "--short", "--client")
-	out, err := cmd.CombinedOutput()
+	out, err := cmd.Output()
 	if err != nil {
 		// Should not happen in normal cases (when helm is properly installed).
 		// Anyway, for now fallback to v2 for backward compatibility for helm-s3 users that are still on v2.


### PR DESCRIPTION
if there are warnings in the helm output (such as kubeconfig permissions too loose) it will cause the version to erroneously be detected as V2.