### PR TITLE
fix: tar bin/helm-s3 Not found in archive

### DIFF
--- a/hack/install.sh
+++ b/hack/install.sh
@@ -20,30 +20,29 @@ validate_checksum() {
 }
 
 initArch() {
-  arch=$(uname -m)
-  case $arch in
-    x86_64|amd64) arch="amd64" ;;
-    aarch64|arm64) arch="arm64" ;;
-    *)
-      echo "Arch '$(uname -m)' not supported!" >&2
-      exit 1
-      ;;
-  esac
-
+    arch=$(uname -m)
+    case $arch in
+        x86_64|amd64) arch="amd64" ;;
+        aarch64|arm64) arch="arm64" ;;
+        *)
+        echo "Arch '$(uname -m)' not supported!" >&2
+        exit 1
+        ;;
+    esac
 }
 
 initOS() {
-  os=$(uname -s)
-  binary_extension=""
-  case "$(uname)" in
-    Darwin) os="darwin" ;;
-    Linux) os="linux" ;;
-    CYGWIN*|MINGW*|MSYS_NT*) os="windows"; binary_extension=".exe" ;;
-    *)
-      echo "OS '$(uname)' not supported!" >&2
-      exit 1
-      ;;
-  esac
+    os=$(uname -s)
+    binary_extension=""
+    case "$(uname)" in
+        Darwin) os="darwin" ;;
+        Linux) os="linux" ;;
+        CYGWIN*|MINGW*|MSYS_NT*) os="windows"; binary_extension=".exe" ;;
+        *)
+        echo "OS '$(uname)' not supported!" >&2
+        exit 1
+        ;;
+    esac
 }
 
 on_exit() {

--- a/hack/install.sh
+++ b/hack/install.sh
@@ -34,10 +34,11 @@ initArch() {
 
 initOS() {
   os=$(uname -s)
+  binary_extension=""
   case "$(uname)" in
     Darwin) os="darwin" ;;
     Linux) os="linux" ;;
-    CYGWIN*|MINGW*|MSYS_NT*) os="windows" ;;
+    CYGWIN*|MINGW*|MSYS_NT*) os="windows"; binary_extension=".exe" ;;
     *)
       echo "OS '$(uname)' not supported!" >&2
       exit 1
@@ -96,4 +97,4 @@ checksums_filename="releases/v${version}_checksums.txt"
 )
 
 # Unpack the binary.
-tar xzf "${binary_filename}" bin/helm-s3
+tar xzf "${binary_filename}" "bin/helm-s3${binary_extension}"

--- a/hack/install.sh
+++ b/hack/install.sh
@@ -34,12 +34,12 @@ initArch() {
 initOS() {
     os=$(uname -s)
     binary_extension=""
-    case "$(uname)" in
+    case "$(os)" in
         Darwin) os="darwin" ;;
         Linux) os="linux" ;;
         CYGWIN*|MINGW*|MSYS_NT*) os="windows"; binary_extension=".exe" ;;
         *)
-        echo "OS '$(uname)' not supported!" >&2
+        echo "OS '$(os)' not supported!" >&2
         exit 1
         ;;
     esac


### PR DESCRIPTION
**What type of PR is this?**
/kind fix

**What this PR does / why we need it**:
This PR fixes `helm-s3` plugin installation on Windows (CYGWIN, MINGW, MSYS_NT) platforms.
Can be reproduced via installing any version above `v0.14.0`, example:
```
$ helm plugin install https://github.com/hypnoglow/helm-s3.git --version v0.16.2
Downloading and installing helm-s3 v0.16.2 ...
Checksum is valid.
tar: bin/helm-s3: Not found in archive
tar: Exiting with failure status due to previous errors
helm-s3 install hook failed. Please remove the plugin using 'helm plugin remove s3' and install again.
Error: plugin install hook for "s3" exited with error
```

This issue started happening after chaning the way of extracting the binary from the tarball: https://github.com/hypnoglow/helm-s3/commit/e9e538249267cc499c2c56188865981acd6b00f9#diff-3bac97673cfc352e120c81f8812245c509aa6dfe24f5eeeb07162159fe82aef5L99
While `mv` command is good with moving binary without explicit extension definition, the `tar` is pretty restrictive on this, so it's failing on the extraction stage. So, I just added `binary_extension` variable which would be empty for UNIX/Linux systems, and `.exe` suffix will be appended for Windows installations.

Also this MR fixes `os` variable usage, the previous `initOS` function had `os` definition with `uname -s` value and there are unecessary  plain `uname` calls happening later on.

Fixed <4-spaces indentations as well.

**Which issue(s) this PR fixes**:
- https://github.com/hypnoglow/helm-s3/issues/462

**Special notes for your reviewer**:
NONE

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fixes helm-s3 plugin installation on Windows platforms
```
