### PR TITLE
Fixed the OS Variable on initOS

### DIFF
--- a/hack/install.sh
+++ b/hack/install.sh
@@ -34,12 +34,12 @@ initArch() {
 initOS() {
     os=$(uname -s)
     binary_extension=""
-    case "$(os)" in
+    case ${os} in
         Darwin) os="darwin" ;;
         Linux) os="linux" ;;
         CYGWIN*|MINGW*|MSYS_NT*) os="windows"; binary_extension=".exe" ;;
         *)
-        echo "OS '$(os)' not supported!" >&2
+        echo "OS '${os}' not supported!" >&2
         exit 1
         ;;
     esac


### PR DESCRIPTION
The initOS introduced variable OS but it was not working because of the fact that we haven't used` ${os} `and we used `$(os)`

It caused the installation breaks and doesn't work at all:

```
./hack/install.sh: line 37: os: not found
./hack/install.sh: line 42: os: not found
OS '' not supported!
```

The propose of this Pull Request is to have a quick fix for this issue 