### PR TITLE
fix install script failing on trying to execute `os`

### DIFF
--- a/hack/install.sh
+++ b/hack/install.sh
@@ -32,9 +32,9 @@ initArch() {
 }
 
 initOS() {
-    os=$(uname -s)
+    os="$(uname -s)"
     binary_extension=""
-    case "$(os)" in
+    case "${os}" in
         Darwin) os="darwin" ;;
         Linux) os="linux" ;;
         CYGWIN*|MINGW*|MSYS_NT*) os="windows"; binary_extension=".exe" ;;

--- a/hack/install.sh
+++ b/hack/install.sh
@@ -39,7 +39,7 @@ initOS() {
         Linux) os="linux" ;;
         CYGWIN*|MINGW*|MSYS_NT*) os="windows"; binary_extension=".exe" ;;
         *)
-        echo "OS '$(os)' not supported!" >&2
+        echo "OS '${os}' not supported!" >&2
         exit 1
         ;;
     esac


### PR DESCRIPTION
```
./hack/install.sh: 37: os: not found
./hack/install.sh: 42: os: not found
OS '' not supported!
```