### PR TITLE
:rocket: release 0.17.2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,6 @@ jobs:
           version: latest
           args: release --clean --config=.goreleaser.yml
         env:
-          GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # Useful if you want to use not the latest tag for changelog.
           GORELEASER_PREVIOUS_TAG: ""

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,5 +1,5 @@
 name: "s3"
-version: "0.17.1"
+version: "0.17.2"
 usage: "Manage chart repositories on Amazon S3"
 description: |-
   Provides AWS S3 protocol support for charts and repos. https://github.com/hypnoglow/helm-s3


### PR DESCRIPTION
Patch release. Closes #602.

CVE fixes already in master via Dependabot:

- `google.golang.org/grpc` 1.72.1 → 1.79.3 (CVE-2026-33186, CRITICAL)
- `github.com/containerd/containerd` 1.7.29 → 1.7.32 (CVE-2026-46680, HIGH)
- `github.com/moby/spdystream` 0.5.0 → 0.5.1 (CVE-2026-35469, HIGH)
- `helm.sh/helm/v3` — CVE-2026-35206 addressed transitively (MEDIUM)

Also drops a dead `GPG_FINGERPRINT` env from `release.yml` that referenced a non-existent `import_gpg` step; release behaviour unchanged.