### PR TITLE
Switch Dependabot auto-merge to /lgtm comment trigger

### DIFF
--- a/.github/workflows/dependabot-major-merge.yml
+++ b/.github/workflows/dependabot-major-merge.yml
@@ -1,30 +1,25 @@
-name: Dependabot auto-merge (major)
+name: Dependabot auto-merge (LGTM)
 
 on:
-  pull_request_review:
+  issue_comment:
     types:
-      - submitted
+      - created
 
 jobs:
-  dependabot-major-merge:
-    name: Auto-merge major Dependabot PRs
+  dependabot-lgtm-merge:
+    name: Auto-merge Dependabot PR on /lgtm
     if: >-
-      github.event.review.state == 'approved'
-      && github.event.pull_request.user.login == 'dependabot[bot]'
-      && github.event.review.author_association == 'OWNER'
+      github.event.issue.pull_request != null
+      && github.event.issue.user.login == 'dependabot[bot]'
+      && github.event.comment.body == '/lgtm'
+      && github.event.comment.author_association == 'OWNER'
     permissions:
       contents: write
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-      - name: Dependabot metadata
-        id: metadata
-        uses: dependabot/fetch-metadata@21025c705c08248db411dc16f3619e6b5f9ea21a # v2.5.0
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Enable auto-merge for approved major Dependabot PRs
-        if: steps.metadata.outputs.update-type == 'version-update:semver-major'
-        run: gh pr merge --auto --merge "$PR_URL"
+      - name: Enable auto-merge
         env:
-          PR_URL: ${{ github.event.pull_request.html_url }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ github.event.issue.html_url }}
+        run: gh pr merge --auto --merge "$PR_URL"


### PR DESCRIPTION
The pull_request_review event from #610 does not fire on Dependabot PRs. Use issue_comment with `/lgtm` from the repo OWNER instead.