### PR TITLE
Use squash merge in Dependabot auto-merge workflows

### DIFF
--- a/.github/workflows/dependabot-major-merge.yml
+++ b/.github/workflows/dependabot-major-merge.yml
@@ -22,4 +22,4 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_URL: ${{ github.event.issue.html_url }}
-        run: gh pr merge --auto --merge "$PR_URL"
+        run: gh pr merge --auto --squash "$PR_URL"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -222,7 +222,7 @@ jobs:
         if: >-
           steps.metadata.outputs.update-type == 'version-update:semver-minor'
           || steps.metadata.outputs.update-type == 'version-update:semver-patch'
-        run: gh pr merge --auto --merge "$PR_URL"
+        run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Switch both Dependabot auto-merge workflows from `--merge` to `--squash`.

Merge commits are no longer allowed on the repository; only rebase and squash are enabled, so `gh pr merge --auto --merge` would fail.