### PR TITLE
Add actions:write permission to Dependabot auto-merge workflows

### DIFF
--- a/.github/workflows/dependabot-major-merge.yml
+++ b/.github/workflows/dependabot-major-merge.yml
@@ -16,6 +16,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      actions: write
     runs-on: ubuntu-latest
     steps:
       - name: Enable auto-merge

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -211,6 +211,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      actions: write
     runs-on: ubuntu-latest
     steps:
       - name: Dependabot metadata


### PR DESCRIPTION
## Summary

When a Dependabot PR modifies a workflow file (e.g. bumping `dependabot/fetch-metadata` used in `main.yml`), `gh pr merge --auto --squash` fails with:

> GraphQL: Pull request refusing to allow a GitHub App to create or update workflow `.github/workflows/main.yml` without `workflows` permission (enablePullRequestAutoMerge)

The default `GITHUB_TOKEN` cannot be granted the `workflows` OAuth scope. Empirically, adding `actions: write` to the job's `permissions` block works around this — see [cli/cli#11493](https://github.com/cli/cli/issues/11493) for the (undocumented) behavior.

Fixes the `/lgtm` failure on #596.