### PR TITLE
Use PAT for Dependabot auto-merge to allow workflow-file PRs

### DIFF
--- a/.github/workflows/dependabot-major-merge.yml
+++ b/.github/workflows/dependabot-major-merge.yml
@@ -16,11 +16,12 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-      actions: write
     runs-on: ubuntu-latest
     steps:
       - name: Enable auto-merge
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Use a dedicated token instead of GITHUB_TOKEN so that
+          # auto-merge works on PRs that modify workflow files.
+          GH_TOKEN: ${{ secrets.DEPENDABOT_AUTOMERGE_TOKEN }}
           PR_URL: ${{ github.event.issue.html_url }}
         run: gh pr merge --auto --squash "$PR_URL"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -211,7 +211,6 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-      actions: write
     runs-on: ubuntu-latest
     steps:
       - name: Dependabot metadata
@@ -226,4 +225,6 @@ jobs:
         run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Use a dedicated token instead of GITHUB_TOKEN so that
+          # auto-merge works on PRs that modify workflow files.
+          GH_TOKEN: ${{ secrets.DEPENDABOT_AUTOMERGE_TOKEN }}


### PR DESCRIPTION
## Summary

The previous workaround did not help — `gh pr merge --auto` still fails with the `workflows permission` error on PRs that modify workflow files.

Switch the auto-merge step in both workflows to use a token stored as the `DEPENDABOT_AUTOMERGE_TOKEN` secret.

`dependabot/fetch-metadata` keeps using `GITHUB_TOKEN` — it only reads PR metadata.