### PR TITLE
Rename and tidy workflow display names

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 # Reference: https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax
 
-name: main
+name: CI
 
 on:
   push:

--- a/.github/workflows/dependabot-lgtm-merge.yml
+++ b/.github/workflows/dependabot-lgtm-merge.yml
@@ -1,4 +1,4 @@
-name: Dependabot auto-merge (LGTM)
+name: Dependabot Auto-Merge (LGTM)
 
 on:
   issue_comment:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: release
+name: Release
 
 on:
   push:

--- a/.github/workflows/reusable-docker-images.yml
+++ b/.github/workflows/reusable-docker-images.yml
@@ -1,4 +1,4 @@
-name: docker-images
+name: Reusable / Docker Images
 
 on:
   workflow_call:

--- a/.github/workflows/reusable-test-install.yml
+++ b/.github/workflows/reusable-test-install.yml
@@ -1,4 +1,4 @@
-name: test-install
+name: Reusable / Test Install
 
 on:
   workflow_call:

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <p align="left"><img src=".github/assets/icon_with_name.png" width="500" alt="helm-s3 Logo"></p>
 
-[![main](https://github.com/hypnoglow/helm-s3/actions/workflows/main.yml/badge.svg)](https://github.com/hypnoglow/helm-s3/actions/workflows/main.yml)
-[![release](https://github.com/hypnoglow/helm-s3/actions/workflows/release.yml/badge.svg)](https://github.com/hypnoglow/helm-s3/actions/workflows/release.yml)
+[![CI](https://github.com/hypnoglow/helm-s3/actions/workflows/ci.yml/badge.svg)](https://github.com/hypnoglow/helm-s3/actions/workflows/ci.yml)
+[![Release](https://github.com/hypnoglow/helm-s3/actions/workflows/release.yml/badge.svg)](https://github.com/hypnoglow/helm-s3/actions/workflows/release.yml)
 [![codecov](https://codecov.io/gh/hypnoglow/helm-s3/branch/master/graph/badge.svg?token=lJqiDsDfPu)](https://codecov.io/gh/hypnoglow/helm-s3)
 [![License MIT](https://img.shields.io/badge/license-MIT-blue.svg?style=flat)](LICENSE)
 [![GitHub release](https://img.shields.io/github/release/hypnoglow/helm-s3.svg)](https://github.com/hypnoglow/helm-s3/releases)


### PR DESCRIPTION
## Summary

- `main.yml` → `ci.yml` (`name: CI`)
- `dependabot-major-merge.yml` → `dependabot-lgtm-merge.yml` — filename now matches behavior (merges any Dependabot PR on `/lgtm`)
- Title-case `name:` across all workflows for UI consistency
- Group reusable workflows under `Reusable / ...` prefix so they sort together in the Actions sidebar
- Update README badges to new paths

Note for after merge: check branch protection settings — required status check job names (`Build`, `Run end-to-end tests`, `Status check`, etc.) are unchanged, so checks should remain valid, but worth a glance.