### PR TITLE
Rename default branch from master to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ name: CI
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
     branches:
       - '*'
@@ -182,7 +182,7 @@ jobs:
     needs:
       - test-e2e
     uses: ./.github/workflows/reusable-test-install.yml
-    if: github.ref_name == 'master'
+    if: github.ref_name == 'main'
 
   # This job's only purpose is to be used for the "Require status checks to pass
   # before merging" feature.

--- a/.github/workflows/reusable-docker-images.yml
+++ b/.github/workflows/reusable-docker-images.yml
@@ -51,8 +51,8 @@ jobs:
             
             let plugin_version = `commit.${context.sha}`
             let push = false
-            if (GITHUB_REF_TYPE === "branch" && GITHUB_REF_NAME === "master") {
-              plugin_version = "master"
+            if (GITHUB_REF_TYPE === "branch" && GITHUB_REF_NAME === "main") {
+              plugin_version = "main"
               push = true
             }
             if (GITHUB_REF_TYPE === "tag") {

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -23,4 +23,4 @@ archives:
 
 release:
   header: |
-    See descriptive changelog in [CHANGELOG.md](https://github.com/hypnoglow/helm-s3/blob/master/CHANGELOG.md).
+    See descriptive changelog in [CHANGELOG.md](https://github.com/hypnoglow/helm-s3/blob/main/CHANGELOG.md).

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![CI](https://github.com/hypnoglow/helm-s3/actions/workflows/ci.yml/badge.svg)](https://github.com/hypnoglow/helm-s3/actions/workflows/ci.yml)
 [![Release](https://github.com/hypnoglow/helm-s3/actions/workflows/release.yml/badge.svg)](https://github.com/hypnoglow/helm-s3/actions/workflows/release.yml)
-[![codecov](https://codecov.io/gh/hypnoglow/helm-s3/branch/master/graph/badge.svg?token=lJqiDsDfPu)](https://codecov.io/gh/hypnoglow/helm-s3)
+[![codecov](https://codecov.io/gh/hypnoglow/helm-s3/branch/main/graph/badge.svg?token=lJqiDsDfPu)](https://codecov.io/gh/hypnoglow/helm-s3)
 [![License MIT](https://img.shields.io/badge/license-MIT-blue.svg?style=flat)](LICENSE)
 [![GitHub release](https://img.shields.io/github/release/hypnoglow/helm-s3.svg)](https://github.com/hypnoglow/helm-s3/releases)
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/s3)](https://artifacthub.io/packages/search?repo=s3)
@@ -66,7 +66,7 @@ to the plugin, please see [these instructions](.github/CONTRIBUTING.md).
 
 The plugin is also distributed as Docker images. Images are pushed to Docker Hub
 tagged with plugin release version and suffixed with Helm version. The image
-built from master branch is also available, note that it should be only used for
+built from main branch is also available, note that it should be only used for
 playing and testing, it is **strongly discouraged** to use that image for
 production use cases. Refer to https://hub.docker.com/r/hypnoglow/helm-s3 for
 details and all available tags.
@@ -457,7 +457,7 @@ $ export AWS_ENDPOINT=localhost:9000
 $ export AWS_DISABLE_SSL=true
 ```
 
-See [these integration tests](https://github.com/hypnoglow/helm-s3/blob/master/hack/test-e2e-local.sh)
+See [these integration tests](https://github.com/hypnoglow/helm-s3/blob/main/hack/test-e2e-local.sh)
 that use local minio docker container for a complete example.
 
 ### Using S3 bucket ServerSide Encryption
@@ -471,7 +471,7 @@ The plugin will look for the bucket in the region inferred by the environment.
 This can be controlled by exporting one of `HELM_S3_REGION`, `AWS_REGION` or 
 `AWS_DEFAULT_REGION`, in order of precedence.
 
-Since [v0.11.0](https://github.com/hypnoglow/helm-s3/blob/master/CHANGELOG.md#0110---2022-05-24)
+Since [v0.11.0](https://github.com/hypnoglow/helm-s3/blob/main/CHANGELOG.md#0110---2022-05-24)
 the plugin supports dynamic S3 bucket region retrieval, so in most cases you
 don't need to provide the region. The plugin will detect it automatically and
 work without issues.

--- a/cmd/helm-s3/main.go
+++ b/cmd/helm-s3/main.go
@@ -7,7 +7,7 @@ import (
 )
 
 var (
-	version = "master"
+	version = "main"
 )
 
 func main() {

--- a/website/content/docs/advanced-features/index.md
+++ b/website/content/docs/advanced-features/index.md
@@ -148,7 +148,7 @@ $ export AWS_ENDPOINT=localhost:9000
 $ export AWS_DISABLE_SSL=true
 ```
 
-See [these integration tests](https://github.com/hypnoglow/helm-s3/blob/master/hack/test-e2e-local.sh)
+See [these integration tests](https://github.com/hypnoglow/helm-s3/blob/main/hack/test-e2e-local.sh)
 that use local minio docker container for a complete example.
 
 ## Using S3 bucket ServerSide Encryption
@@ -162,7 +162,7 @@ The plugin will look for the bucket in the region inferred by the environment.
 This can be controlled by exporting one of `HELM_S3_REGION`, `AWS_REGION` or
 `AWS_DEFAULT_REGION`, in order of precedence.
 
-Since [v0.11.0](https://github.com/hypnoglow/helm-s3/blob/master/CHANGELOG.md#0110---2022-05-24)
+Since [v0.11.0](https://github.com/hypnoglow/helm-s3/blob/main/CHANGELOG.md#0110---2022-05-24)
 the plugin supports dynamic S3 bucket region retrieval, so in most cases you
 don't need to provide the region. The plugin will detect it automatically and
 work without issues.

--- a/website/content/docs/install/index.md
+++ b/website/content/docs/install/index.md
@@ -17,7 +17,7 @@ You can install a specific release version:
 To use the plugin, you do not need any special dependencies. The installer will
 download versioned release with prebuilt binary from [github releases](https://github.com/hypnoglow/helm-s3/releases).
 However, if you want to build the plugin from source, or you want to contribute
-to the plugin, please see [these instructions](https://github.com/hypnoglow/helm-s3/blob/master/.github/CONTRIBUTING.md).
+to the plugin, please see [these instructions](https://github.com/hypnoglow/helm-s3/blob/main/.github/CONTRIBUTING.md).
 
 ## Docker Images
 
@@ -25,7 +25,7 @@ to the plugin, please see [these instructions](https://github.com/hypnoglow/helm
 
 The plugin is also distributed as Docker images. Images are pushed to Docker Hub
 tagged with plugin release version and suffixed with Helm version. The image
-built from master branch is also available, note that it should be only used for
+built from main branch is also available, note that it should be only used for
 playing and testing, it is **strongly discouraged** to use that image for
 production use cases. Refer to https://hub.docker.com/r/hypnoglow/helm-s3 for
 details and all available tags.


### PR DESCRIPTION
Updates branch references in workflows, the dev-build version string in \`cmd/helm-s3/main.go\`, and live \`/blob/master/...\` links in README and docs to point to \`main\`. Historical CHANGELOG entries are left intact.

The actual branch rename on GitHub still needs to be performed in repo Settings -> Branches. GitHub will redirect the old branch name automatically.